### PR TITLE
[Do Not Merge] Add Meter Tags, Instrument Tags, and Scopes to System Diagnostics Metrics

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -31,10 +31,10 @@
     <ExcludeLatestTargetFramework Condition="'$(ExcludeLatestTargetFramework)' == '' and '$(BuildingInsideVisualStudio)' == 'true'">true</ExcludeLatestTargetFramework>
     <ExcludeLatestTargetFramework Condition="'$(ExcludeLatestTargetFramework)' == ''">false</ExcludeLatestTargetFramework>
     <!-- The TFMs of the dotnet-monitor tool.  -->
-    <ToolTargetFrameworks>net6.0;net8.0</ToolTargetFrameworks>
+    <ToolTargetFrameworks>net6.0</ToolTargetFrameworks>
     <ToolTargetFrameworks Condition="'$(ExcludeLatestTargetFramework)' != 'true'">$(ToolTargetFrameworks);$(LatestTargetFramework)</ToolTargetFrameworks>
     <!-- The TFMs of that the dotnet-monitor tool supports diagnosing. -->
-    <TestTargetFrameworks>net6.0;net7.0;net8.0</TestTargetFrameworks>
+    <TestTargetFrameworks>net6.0;net7.0</TestTargetFrameworks>
     <TestTargetFrameworks Condition="'$(ExcludeLatestTargetFramework)' != 'true'">$(TestTargetFrameworks);$(LatestTargetFramework)</TestTargetFrameworks>
     <!-- The TFM for generating schema.json and OpenAPI docs. -->
     <SchemaTargetFramework>net6.0</SchemaTargetFramework>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -31,10 +31,10 @@
     <ExcludeLatestTargetFramework Condition="'$(ExcludeLatestTargetFramework)' == '' and '$(BuildingInsideVisualStudio)' == 'true'">true</ExcludeLatestTargetFramework>
     <ExcludeLatestTargetFramework Condition="'$(ExcludeLatestTargetFramework)' == ''">false</ExcludeLatestTargetFramework>
     <!-- The TFMs of the dotnet-monitor tool.  -->
-    <ToolTargetFrameworks>net6.0</ToolTargetFrameworks>
+    <ToolTargetFrameworks>net6.0;net8.0</ToolTargetFrameworks>
     <ToolTargetFrameworks Condition="'$(ExcludeLatestTargetFramework)' != 'true'">$(ToolTargetFrameworks);$(LatestTargetFramework)</ToolTargetFrameworks>
     <!-- The TFMs of that the dotnet-monitor tool supports diagnosing. -->
-    <TestTargetFrameworks>net6.0;net7.0</TestTargetFrameworks>
+    <TestTargetFrameworks>net6.0;net7.0;net8.0</TestTargetFrameworks>
     <TestTargetFrameworks Condition="'$(ExcludeLatestTargetFramework)' != 'true'">$(TestTargetFrameworks);$(LatestTargetFramework)</TestTargetFrameworks>
     <!-- The TFM for generating schema.json and OpenAPI docs. -->
     <SchemaTargetFramework>net6.0</SchemaTargetFramework>

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/JsonCounterLogger.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/JsonCounterLogger.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             }
             else if (counter is CounterEndedPayload)
             {
-                Logger.CounterEndedPayload(counter.Name);
+                Logger.CounterEndedPayload(counter.CounterInfo.CounterName);
                 return;
             }
             else if (!counter.EventType.IsValuePublishedEvent())
@@ -70,16 +70,16 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                     Quantile quantile = aggregatePercentilePayload.Quantiles[i];
 
                     SerializeCounterValues(counter.Timestamp,
-                        counter.Provider.ProviderName,
-                        counter.Name,
+                        counter.CounterInfo.ProviderName,
+                        counter.CounterInfo.CounterName,
                         counter.DisplayName,
                         counter.Unit,
                         counter.CounterType.ToString(),
                         CounterUtilities.AppendPercentile(counter.Metadata, quantile.Percentage),
                         quantile.Value,
-                        counter.Provider.MeterTags,
-                        counter.Provider.InstrumentTags,
-                        counter.Provider.ScopeHash);
+                        counter.CounterInfo.MeterTags,
+                        counter.CounterInfo.InstrumentTags,
+                        counter.CounterInfo.ScopeHash);
 
                     if (i < aggregatePercentilePayload.Quantiles.Length - 1)
                     {
@@ -93,16 +93,16 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
                 _bufferWriter.Clear();
 
                 SerializeCounterValues(counter.Timestamp,
-                    counter.Provider.ProviderName,
-                    counter.Name,
+                    counter.CounterInfo.ProviderName,
+                    counter.CounterInfo.CounterName,
                     counter.DisplayName,
                     counter.Unit,
                     counter.CounterType.ToString(),
                     counter.Metadata,
                     counter.Value,
-                    counter.Provider.MeterTags,
-                    counter.Provider.InstrumentTags,
-                    counter.Provider.ScopeHash);
+                    counter.CounterInfo.MeterTags,
+                    counter.CounterInfo.InstrumentTags,
+                    counter.CounterInfo.ScopeHash);
             }
             await _stream.WriteAsync(_bufferWriter.WrittenMemory);
 

--- a/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsStore.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsStore.cs
@@ -30,8 +30,8 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             public override int GetHashCode()
             {
                 HashCode code = new HashCode();
-                code.Add(_metric.Provider);
-                code.Add(_metric.Name);
+                code.Add(_metric.CounterInfo.ProviderName);
+                code.Add(_metric.CounterInfo.CounterName);
                 return code.ToHashCode();
             }
 
@@ -73,9 +73,9 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             //Do not accept CounterEnded payloads.
             if (metric is CounterEndedPayload counterEnded)
             {
-                if (_observedEndedCounters.Add((counterEnded.Provider.ProviderName, counterEnded.Name)))
+                if (_observedEndedCounters.Add((counterEnded.CounterInfo.ProviderName, counterEnded.CounterInfo.CounterName)))
                 {
-                    _logger.CounterEndedPayload(counterEnded.Name);
+                    _logger.CounterEndedPayload(counterEnded.CounterInfo.CounterName);
                 }
                 return;
             }
@@ -137,7 +137,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
             {
                 ICounterPayload metricInfo = metricGroup.Value.First();
 
-                string metricName = PrometheusDataModel.GetPrometheusNormalizedName(metricInfo.Provider.ProviderName, metricInfo.Name, metricInfo.Unit);
+                string metricName = PrometheusDataModel.GetPrometheusNormalizedName(metricInfo.CounterInfo.ProviderName, metricInfo.CounterInfo.CounterName, metricInfo.Unit);
 
                 await WriteMetricHeader(metricInfo, writer, metricName);
 
@@ -243,7 +243,7 @@ namespace Microsoft.Diagnostics.Monitoring.WebApi
 
         private static bool CompareMetrics(ICounterPayload first, ICounterPayload second)
         {
-            return string.Equals(first.Name, second.Name);
+            return string.Equals(first.CounterInfo.CounterName, second.CounterInfo.CounterName);
         }
 
         public void Clear()

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/CounterPayload.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/CounterPayload.cs
@@ -22,5 +22,11 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
 
         [JsonPropertyName("tags")]
         public string Metadata { get; set; }
+
+        [JsonPropertyName("meterTags")]
+        public string MeterTags { get; set; }
+
+        [JsonPropertyName("instrumentTags")]
+        public string InstrumentTags { get; set; }
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/LiveMetricsTestConstants.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/LiveMetricsTestConstants.cs
@@ -11,7 +11,12 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
         public const string HistogramName2 = "test-histogram-2";
         public const string ProviderName1 = "P1";
         public const string ProviderName2 = "P2";
+        public const string ProviderName3 = "P3";
         public const string MetadataKey = "key1";
         public const string MetadataValue = "value1";
+        public const string MeterMetadataKey = "mkey1";
+        public const string MeterMetadataValue = "mvalue1";
+        public const string InstrumentMetadataKey = "ikey1";
+        public const string InstrumentMetadataValue = "ivalue1";
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/LiveMetricsTestUtilities.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/LiveMetricsTestUtilities.cs
@@ -69,10 +69,11 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
             List<string> meterTags,
             List<string> instrumentTags)
         {
-            await AggregateMetrics(actualMetrics, providers, names, metadata);
-
             await foreach (CounterPayload counter in actualMetrics)
             {
+                providers.Add(counter.Provider);
+                names.Add(counter.Name);
+                metadata.Add(counter.Metadata);
                 meterTags.Add(counter.MeterTags);
                 instrumentTags.Add(counter.InstrumentTags);
             }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/LiveMetricsTestUtilities.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.TestCommon/LiveMetricsTestUtilities.cs
@@ -62,6 +62,22 @@ namespace Microsoft.Diagnostics.Monitoring.TestCommon
             }
         }
 
+        internal static async Task AggregateMetrics(IAsyncEnumerable<CounterPayload> actualMetrics,
+            List<string> providers,
+            List<string> names,
+            List<string> metadata,
+            List<string> meterTags,
+            List<string> instrumentTags)
+        {
+            await AggregateMetrics(actualMetrics, providers, names, metadata);
+
+            await foreach (CounterPayload counter in actualMetrics)
+            {
+                meterTags.Add(counter.MeterTags);
+                instrumentTags.Add(counter.InstrumentTags);
+            }
+        }
+
         internal static async IAsyncEnumerable<CounterPayload> GetAllMetrics(Stream liveMetricsStream)
         {
             using var reader = new StreamReader(liveMetricsStream);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LiveMetricsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LiveMetricsTests.cs
@@ -417,9 +417,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                         actualInstrumentNames.ToHashSet(),
                         strict: true);
 
-                    // NOTE: This assumes the default percentiles of 50/95/99 - if this changes, this test
-                    // will fail and will need to be updated.
-
                     string actualMeterTag = Assert.Single(actualMeterTags.Distinct());
                     string expectedMeterTag = Constants.MeterMetadataKey + "=" + Constants.MeterMetadataValue;
                     Assert.Equal(expectedMeterTag, actualMeterTag);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LiveMetricsTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests/LiveMetricsTests.cs
@@ -361,6 +361,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                 });
         }
 
+#if NET8_0_OR_GREATER
         [Fact]
         public async Task TestSystemDiagnosticsMetrics_MeterInstrumentTags()
         {
@@ -444,5 +445,6 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.FunctionalTests
                     });
                 });
         }
+#endif
     }
 }

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/MetricsFormattingTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/MetricsFormattingTests.cs
@@ -44,16 +44,16 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         {
             List<ICounterPayload> payload = new();
 
-            Provider provider = new Provider(MeterName, null, null, null);
+            CachedCounterInfo counterInfo = new CachedCounterInfo(MeterName, InstrumentName, null, null, null);
 
-            payload.Add(new AggregatePercentilePayload(provider, InstrumentName, "DisplayName", string.Empty, string.Empty,
+            payload.Add(new AggregatePercentilePayload(counterInfo, "DisplayName", string.Empty, string.Empty,
                 new Quantile[] { new Quantile(0.5, Value1), new Quantile(0.95, Value2), new Quantile(0.99, Value3) },
                 Timestamp));
 
             using MemoryStream stream = await GetMetrics(payload);
             List<string> lines = ReadStream(stream);
 
-            string metricName = $"{MeterName.ToLowerInvariant()}_{payload[0].Name}";
+            string metricName = $"{MeterName.ToLowerInvariant()}_{payload[0].CounterInfo.CounterName}";
 
             const string quantile_50 = "{quantile=\"0.5\"}";
             const string quantile_95 = "{quantile=\"0.95\"}";
@@ -70,15 +70,15 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         [Fact]
         public async Task GaugeFormat_Test()
         {
-            Provider provider = new Provider(MeterName, null, null, null);
+            CachedCounterInfo counterInfo = new CachedCounterInfo(MeterName, InstrumentName, null, null, null);
 
-            ICounterPayload payload = new GaugePayload(provider, InstrumentName, "DisplayName", "", null, Value1, Timestamp);
+            ICounterPayload payload = new GaugePayload(counterInfo, "DisplayName", "", null, Value1, Timestamp);
 
             MemoryStream stream = await GetMetrics(new() { payload });
 
             List<string> lines = ReadStream(stream);
 
-            string metricName = $"{MeterName.ToLowerInvariant()}_{payload.Name}";
+            string metricName = $"{MeterName.ToLowerInvariant()}_{payload.CounterInfo.CounterName}";
 
             Assert.Equal(3, lines.Count);
             Assert.Equal(FormattableString.Invariant($"# HELP {metricName}{payload.Unit} {payload.DisplayName}"), lines[0]);
@@ -89,15 +89,15 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         [Fact]
         public async Task CounterFormat_Test()
         {
-            Provider provider = new Provider(MeterName, null, null, null);
+            CachedCounterInfo counterInfo = new CachedCounterInfo(MeterName, InstrumentName, null, null, null);
 
-            ICounterPayload payload = new RatePayload(provider, InstrumentName, "DisplayName", "", null, Value1, IntervalSeconds, Timestamp);
+            ICounterPayload payload = new RatePayload(counterInfo, "DisplayName", "", null, Value1, IntervalSeconds, Timestamp);
 
             MemoryStream stream = await GetMetrics(new() { payload });
 
             List<string> lines = ReadStream(stream);
 
-            string metricName = $"{MeterName.ToLowerInvariant()}_{payload.Name}";
+            string metricName = $"{MeterName.ToLowerInvariant()}_{payload.CounterInfo.CounterName}";
 
             Assert.Equal(3, lines.Count);
             Assert.Equal($"# HELP {metricName}{payload.Unit} {payload.DisplayName}", lines[0]);
@@ -112,15 +112,15 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
             string instrumentTags = "InstrumentTagKey=InstrumentTagValue,InstrumentTagKey2=InstrumentTagValue2";
             string scopeHash = "123";
 
-            Provider provider = new Provider(MeterName, meterTags, instrumentTags, scopeHash);
+            CachedCounterInfo counterInfo = new CachedCounterInfo(MeterName, InstrumentName, meterTags, instrumentTags, scopeHash);
 
-            ICounterPayload payload = new RatePayload(provider, InstrumentName, "DisplayName", "", null, Value1, IntervalSeconds, Timestamp);
+            ICounterPayload payload = new RatePayload(counterInfo, "DisplayName", "", null, Value1, IntervalSeconds, Timestamp);
 
             MemoryStream stream = await GetMetrics(new() { payload });
 
             List<string> lines = ReadStream(stream);
 
-            string metricName = $"{MeterName.ToLowerInvariant()}_{payload.Name}";
+            string metricName = $"{MeterName.ToLowerInvariant()}_{payload.CounterInfo.CounterName}";
             string metricTags = "{MeterTagKey=\"MeterTagValue\", MeterTagKey2=\"MeterTagValue2\", InstrumentTagKey=\"InstrumentTagValue\", InstrumentTagKey2=\"InstrumentTagValue2\"}";
 
             Assert.Equal(3, lines.Count);
@@ -132,15 +132,15 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         [Fact]
         public async Task UpDownCounterFormat_Test()
         {
-            Provider provider = new Provider(MeterName, null, null, null);
+            CachedCounterInfo counterInfo = new CachedCounterInfo(MeterName, InstrumentName, null, null, null);
 
-            ICounterPayload payload = new UpDownCounterPayload(provider, InstrumentName, "DisplayName", "", null, Value1, Timestamp);
+            ICounterPayload payload = new UpDownCounterPayload(counterInfo, "DisplayName", "", null, Value1, Timestamp);
 
             MemoryStream stream = await GetMetrics(new() { payload });
 
             List<string> lines = ReadStream(stream);
 
-            string metricName = $"{MeterName.ToLowerInvariant()}_{payload.Name}";
+            string metricName = $"{MeterName.ToLowerInvariant()}_{payload.CounterInfo.CounterName}";
 
             Assert.Equal(3, lines.Count);
             Assert.Equal(FormattableString.Invariant($"# HELP {metricName}{payload.Unit} {payload.DisplayName}"), lines[0]);

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/MetricsFormattingTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/MetricsFormattingTests.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
+using Provider = Microsoft.Diagnostics.Monitoring.EventPipe.Provider;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/MetricsFormattingTests.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.Tool.UnitTests/MetricsFormattingTests.cs
@@ -12,7 +12,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
-using Provider = Microsoft.Diagnostics.Monitoring.EventPipe.Provider;
 
 namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
 {
@@ -45,8 +44,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         {
             List<ICounterPayload> payload = new();
 
-            Provider provider = new Provider();
-            provider.ProviderName = MeterName;
+            Provider provider = new Provider(MeterName, null, null, null);
 
             payload.Add(new AggregatePercentilePayload(provider, InstrumentName, "DisplayName", string.Empty, string.Empty,
                 new Quantile[] { new Quantile(0.5, Value1), new Quantile(0.95, Value2), new Quantile(0.99, Value3) },
@@ -72,8 +70,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         [Fact]
         public async Task GaugeFormat_Test()
         {
-            Provider provider = new Provider();
-            provider.ProviderName = MeterName;
+            Provider provider = new Provider(MeterName, null, null, null);
 
             ICounterPayload payload = new GaugePayload(provider, InstrumentName, "DisplayName", "", null, Value1, Timestamp);
 
@@ -92,8 +89,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         [Fact]
         public async Task CounterFormat_Test()
         {
-            Provider provider = new Provider();
-            provider.ProviderName = MeterName;
+            Provider provider = new Provider(MeterName, null, null, null);
 
             ICounterPayload payload = new RatePayload(provider, InstrumentName, "DisplayName", "", null, Value1, IntervalSeconds, Timestamp);
 
@@ -136,8 +132,7 @@ namespace Microsoft.Diagnostics.Monitoring.Tool.UnitTests
         [Fact]
         public async Task UpDownCounterFormat_Test()
         {
-            Provider provider = new Provider();
-            provider.ProviderName = MeterName;
+            Provider provider = new Provider(MeterName, null, null, null);
 
             ICounterPayload payload = new UpDownCounterPayload(provider, InstrumentName, "DisplayName", "", null, Value1, Timestamp);
 

--- a/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/MetricsScenario.cs
+++ b/src/Tests/Microsoft.Diagnostics.Monitoring.UnitTestApp/Scenarios/MetricsScenario.cs
@@ -37,6 +37,21 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
                 Meter meter2 = new Meter(Constants.ProviderName2, "1.0.0");
                 Counter<int> counter2 = meter2.CreateCounter<int>(Constants.CounterName);
 
+                var meterTags = new Dictionary<string, object>
+                {
+                    { Constants.MeterMetadataKey, Constants.MeterMetadataValue }
+                };
+
+                var instrumentTags = new Dictionary<string, object>
+                {
+                    { Constants.InstrumentMetadataKey, Constants.InstrumentMetadataValue }
+                };
+
+#if NET8_0_OR_GREATER
+                Meter meter3 = new Meter(Constants.ProviderName3, "1.0.0", meterTags);
+                Counter<int> counter3 = meter3.CreateCounter<int>(Constants.CounterName, null, null, instrumentTags);
+#endif
+
                 var metadata = new Dictionary<string, object>
                 {
                     { Constants.MetadataKey, Constants.MetadataValue }
@@ -53,6 +68,10 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTestApp.Scenarios
                     }
 
                     counter2.Add(1);
+
+#if NET8_0_OR_GREATER
+                    counter3.Add(1, metadata.ToArray());
+#endif
 
                     await Task.Delay(100);
                 }


### PR DESCRIPTION
###### Summary

This PR goes along with https://github.com/dotnet/diagnostics/pull/4324 in the diagnostics repo.

This PR adds meter tags, instrument tags, and scopes to System Diagnostics Metrics. There is currently a limitation (see https://github.com/dotnet/runtime/issues/93097) around having multiple providers with the same name. As a result, this PR currently makes the assumption that all meters have unique names. 

Quick note - this PR is currently targeting the unification branch, but shouldn't be merged into main until that PR has been merged.

Closes #5140

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
Add Support for Meter Tags and Instrument Tags for System Diagnostics Metrics.
